### PR TITLE
Fasterscan

### DIFF
--- a/celldb/client/client.py
+++ b/celldb/client/client.py
@@ -108,7 +108,8 @@ def list_features(cursor):
     :return:
     """
     keybase = "feature:*"
-    return _pretty_keys(cursor.scan_iter(match=keybase), "feature:")
+    return _pretty_keys(
+        cursor.scan_iter(count=5000, match=keybase), "feature:")
 
 
 def _pretty_keys(keys, remove):
@@ -129,7 +130,8 @@ def list_samples(cursor):
     :param cursor:
     :return:
     """
-    return _pretty_keys(cursor.scan_iter(match="sample:*"), "sample:")
+    return _pretty_keys(
+        cursor.scan_iter(count=5000, match="sample:*"), "sample:")
 
 
 def _string_to_float(string_list):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     namespace_packages=["celldb"],
     zip_safe=False,
     url="https://github.com/david4096/celldb",
-    version=2.1,
+    version=2.2,
     entry_points={
         'console_scripts': [] # TODO add one for SQL line
     },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -175,6 +175,29 @@ class TestUpsertTimes:
         end = time.time()
         assert (end - start) / float(n_samples) < per_sample
 
+    def test_list_many(self):
+        """
+        Makes sure both upsert and list happen in appropriate time
+        :return:
+        """
+        connection = celldb.connect(URL)
+        _drop_tables(connection)
+        list_time = 30
+        per_sample = 1
+        n_samples = 10000
+        n_features = 10
+        sample_ids, feature_ids, vectors = _random_dataset(
+            n_samples, n_features)
+        start = time.time()
+        celldb.upsert_samples(connection, sample_ids, feature_ids, vectors)
+        end = time.time()
+        assert (end - start) / float(n_samples) < per_sample
+        start = time.time()
+        sample_list = list(celldb.list_samples(connection))
+        end = time.time()
+        assert (end - start) < list_time
+        assert len(sample_list) == len(sample_ids)
+
 
 class TestMatrix:
     """


### PR DESCRIPTION
Suggest to the scan to return more values using the `count` keyword.

Anecdotally improved test times by ~1s out of 6s.

Switches to sets for handling samples and features.