### PR TITLE
ETL Workaround and hash keys

### DIFF
--- a/celldb/client/client.py
+++ b/celldb/client/client.py
@@ -110,17 +110,6 @@ def list_features(cursor):
     return cursor.sscan_iter("features", count=200000)
 
 
-def _pretty_keys(keys, remove):
-    """
-    Takes an iterator of singletons and removes the substring to return nice
-    identifiers.
-    :param keys:
-    :param remove:
-    :return:
-    """
-    return (x.replace(remove, '') for x in keys)
-
-
 def list_samples(cursor):
     """
     A convenience function for accessing the list of sampleIds from the

--- a/celldb/client/client.py
+++ b/celldb/client/client.py
@@ -104,8 +104,10 @@ def list_features(cursor):
     :param cursor:
     :return:
     """
-    return _pretty_keys(
-        cursor.sscan_iter("features", count=50), "feature:")
+    # We set our count to be excessively high to optimize listing of all of
+    # the features at once. Providing this via the client might be nice.
+    # number of transcripts ~ 200k
+    return cursor.sscan_iter("features", count=200000)
 
 
 def _pretty_keys(keys, remove):
@@ -127,8 +129,7 @@ def list_samples(cursor):
     :return:
     """
 
-    return _pretty_keys(
-        cursor.sscan_iter("samples", count=50), "sample:")
+    return cursor.sscan_iter("samples", count=5000)
 
 
 def _string_to_float(string_list):

--- a/celldb/client/client.py
+++ b/celldb/client/client.py
@@ -137,7 +137,8 @@ def _safe_float_vector(iterable):
     :param iterable:
     :return:
     """
-    return [float(x) if x else None for x in iterable]
+    # FIXME workaround in client to deal with data ingestion problem
+    return [float(x) if x and x != 'NA' else None for x in iterable]
 
 
 def _get_safe_float_vector(connection, keys):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     namespace_packages=["celldb"],
     zip_safe=False,
     url="https://github.com/david4096/celldb",
-    version=2.2,
+    version=2.3,
     entry_points={
         'console_scripts': [] # TODO add one for SQL line
     },

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     namespace_packages=["celldb"],
     zip_safe=False,
     url="https://github.com/david4096/celldb",
-    version=2.3,
+    version=2.4,
     entry_points={
         'console_scripts': [] # TODO add one for SQL line
     },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -272,3 +272,24 @@ class TestMatrix:
         feature_ids = celldb.list_features(connection)
         assert set(feature_ids) == set(featureIds)
         _drop_tables(connection)
+
+    def test_large_matrix(self):
+        """
+        Tests to make sure that when request a large matrix we get satisfactory
+        results.
+
+        :return:
+        """
+        connection = celldb.connect(URL)
+        #  The amount of time in seconds per point we're willing to accept
+        per_point = 0.01
+        n_samples = 10000
+        n_features = 40
+        points = float(n_samples * n_features)
+        sampleIds, featureIds, vectors = _random_dataset(10000, 40)
+        celldb.upsert_samples(connection, sampleIds, featureIds, vectors)
+        start = time.time()
+        matrix = celldb.matrix(connection, sampleIds, featureIds)
+        assert len(matrix) == len(sampleIds)
+        end = time.time()
+        assert (end - start) / points < per_point


### PR DESCRIPTION
Works around a value problem in loading values from rnaseqer API.

Uses hash keys instead of complex keys for improved performance.