### PR TITLE
Sparse

### DIFF
--- a/celldb/client/__init__.py
+++ b/celldb/client/__init__.py
@@ -4,7 +4,8 @@ from client import (
     list_features,
     list_samples,
     matrix,
-    upsert_samples)
+    upsert_samples,
+    sparse_dict)
 
 assert connect
 assert upsert_sample
@@ -12,3 +13,4 @@ assert list_features
 assert list_samples
 assert matrix
 assert upsert_samples
+assert sparse_dict

--- a/celldb/client/__init__.py
+++ b/celldb/client/__init__.py
@@ -5,7 +5,7 @@ from client import (
     list_samples,
     matrix,
     upsert_samples,
-    sparse_dict)
+    sparse_matrix)
 
 assert connect
 assert upsert_sample
@@ -13,4 +13,4 @@ assert list_features
 assert list_samples
 assert matrix
 assert upsert_samples
-assert sparse_dict
+assert sparse_matrix

--- a/celldb/client/client.py
+++ b/celldb/client/client.py
@@ -49,7 +49,10 @@ def _upsert_sample(cursor, sample_id, feature_ids, values):
     """
     # add a sample key/value pair
     cursor.sadd("samples", sample_id)
-    return _multi_hash_upsert(cursor, sample_id, feature_ids, values)
+    # We just don't upsert zeros!
+    filtered_f, filtered_v = zip(*filter(
+        lambda (x, y): y > 0, zip(feature_ids, values)))
+    return _multi_hash_upsert(cursor, sample_id, filtered_f, filtered_v)
 
 
 def _upsert_features(cursor, feature_ids):
@@ -191,6 +194,15 @@ def matrix(connection, sample_ids, feature_ids):
     return map(
         lambda x: _build_matrix_row(connection, x, feature_ids), sample_ids)
 
+
+def _sparse_matrix(connection, sample_ids, feature_ids):
+    """
+    Creates a sparse representation that can be rebuilt into a csr matrix by
+    :param connection:
+    :param sample_ids:
+    :param feature_ids:
+    :return:
+    """
 
 def _safe_fn(fn, *args):
     """

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     namespace_packages=["celldb"],
     zip_safe=False,
     url="https://github.com/david4096/celldb",
-    version=2.4,
+    version=2.5,
     entry_points={
-        'console_scripts': [] # TODO add one for SQL line
+        'console_scripts': []
     },
     long_description=long_description,
     install_requires=install_requires,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -293,3 +293,35 @@ class TestMatrix:
         assert len(matrix) == len(sampleIds)
         end = time.time()
         assert (end - start) / points < per_point
+
+
+class TestSparseMatrix:
+    """
+    These tests attempt an upsert and then demonstrate the functionality
+    of the "sparse_matrix" query function.
+    :return:
+    """
+    @classmethod
+    def setup_class(cls):
+        connection = celldb.connect(URL)
+        cursor = connection
+        _drop_tables(cursor)
+
+    @classmethod
+    def teardown_class(cls):
+        cursor = celldb.connect(URL)
+        _drop_tables(cursor)
+
+    def test_sparse_matrix(self):
+        cursor = celldb.connect(URL)
+        sample_ids, feature_ids, vectors = _random_dataset(4, 4)
+        celldb.upsert_samples(cursor, sample_ids, feature_ids, vectors)
+        matrix = celldb.sparse_matrix(cursor, sample_ids, feature_ids)
+        # The sparse matrix has the list of samples and features at the top
+        # level for convenience. These become indices into the `values` map.
+        assert len(matrix['sample_ids']) == len(sample_ids)
+        assert len(matrix['feature_ids']) == len(feature_ids)
+
+        for k, v in enumerate(matrix['values']):
+            assert vectors[int(k)][int(v)] == vectors[int(k)][int(v)]
+        _drop_tables(cursor)


### PR DESCRIPTION
Add a function to return a sparse dictionary to the client.

Includes storage optimization for avoiding upserting 0's and to avoid passing around 0's using the `sparse_matrix` function.

Issue:
 Loses the granularity of 0 versus None.